### PR TITLE
feat: switch `<binary-name>.stdin` to `true` by default

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -69,7 +69,7 @@
     "^.*\\.stdin$": {
       "type": "boolean",
       "description": "Whether to pass the file text in via stdin.",
-      "default": false
+      "default": true
     }
   },
   "additionalProperties": {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -192,7 +192,7 @@ impl Configuration {
         stdin: get_value(
           &mut config,
           &format!("{}.stdin", binary_key),
-          false,
+          true,
           &mut diagnostics,
         ),
       });

--- a/tests/specs/FormatFile/LongFile.txt
+++ b/tests/specs/FormatFile/LongFile.txt
@@ -1,5 +1,5 @@
 -- resources/alice29.txt --
-~~ lineWidth: 35, timeout: 3, fold: fold -w {{line_width}} -s {{file_path}} ~~
+~~ lineWidth: 35, timeout: 3, fold: fold -w {{line_width}} -s {{file_path}}, fold.stdin: false ~~
 == Long text ==
 // does not matter
 

--- a/tests/specs/FormatFile/LongFileStdin.txt
+++ b/tests/specs/FormatFile/LongFileStdin.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 35, timeout: 3, fold: fold -w {{line_width}} -s, fold.stdin: true ~~
+~~ lineWidth: 35, timeout: 3, fold: fold -w {{line_width}} -s ~~
 == Long text ==
 
 

--- a/tests/specs/General/Associations_Match.txt
+++ b/tests/specs/General/Associations_Match.txt
@@ -1,5 +1,5 @@
 -- resources/test.txt --
-~~ lineWidth: 35, fold: fold -w {{line_width}} -s, fold.stdin: true, fold.associations: **/*.txt ~~
+~~ lineWidth: 35, fold: fold -w {{line_width}} -s, fold.associations: **/*.txt ~~
 == should format when the association matches ==
 Testing this out with some very very long text testing testing testing testing testing.
 

--- a/tests/specs/General/Associations_NoMatch.txt
+++ b/tests/specs/General/Associations_NoMatch.txt
@@ -1,5 +1,5 @@
 -- resources/test.txt --
-~~ lineWidth: 35, fold: fold -w {{line_width}} -s, fold.stdin: true, fold.associations: **/*.rs ~~
+~~ lineWidth: 35, fold: fold -w {{line_width}} -s, fold.associations: **/*.rs ~~
 == should do nothing when the association doesn't match ==
 Testing this out with some very very long text testing testing testing testing testing.
 

--- a/tests/specs/General/Rustfmt.txt
+++ b/tests/specs/General/Rustfmt.txt
@@ -1,5 +1,5 @@
 -- file.rs --
-~~ rustfmt: rustfmt, rustfmt.stdin: true, rustfmt.associations: **/*.rs ~~
+~~ rustfmt: rustfmt, rustfmt.associations: **/*.rs ~~
 == should do nothing when the association doesn't match ==
 struct   Test {    }
 

--- a/tests/specs/General/Stdout_All.txt
+++ b/tests/specs/General/Stdout_All.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 30, fold: fold -w 30 -s, fold.stdin: true ~~
+~~ lineWidth: 30, fold: fold -w 30 -s ~~
 == Process returns the formatted text via stdout ==
 this should be wrapped because it is a long text
 


### PR DESCRIPTION
Switching `stdin` to `true` by default because that's the recommended way of using this.