### PR TITLE
fix: use plugins.dprint.dev for release artifacts

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -98,7 +98,7 @@ const ci = {
             "git config --global core.eol lf",
           ].join("\n"),
         },
-        { uses: "actions/checkout@v4" },
+        { uses: "actions/checkout@v6" },
         { uses: "dsherret/rust-toolchain-file@v1" },
         {
           name: "Cache cargo",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -1,7 +1,7 @@
 import * as yaml from "https://deno.land/std@0.170.0/encoding/yaml.ts";
 
 enum OperatingSystem {
-  Macx86 = "macos-13",
+  Macx86 = "macos-15-intel",
   MacArm = "macos-latest",
   Windows = "windows-latest",
   Linux = "ubuntu-22.04",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: |-
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dsherret/rust-toolchain-file@v1
       - name: Cache cargo
         if: 'startsWith(github.ref, ''refs/tags/'') != true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: macos-13
+          - os: macos-15-intel
             run_tests: 'true'
             target: x86_64-apple-darwin
             cross: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git config user.name "${{ github.actor }}"
-          deno run -A https://raw.githubusercontent.com/dprint/automation/0.10.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}
+          deno run -A jsr:@dprint/automation@0.10.3/tasks/publish-release --${{github.event.inputs.releaseKind}}

--- a/scripts/create_plugin_file.ts
+++ b/scripts/create_plugin_file.ts
@@ -1,8 +1,4 @@
-import {
-  $,
-  CargoToml,
-  processPlugin,
-} from "https://raw.githubusercontent.com/dprint/automation/0.10.0/mod.ts";
+import { $, CargoToml, processPlugin } from "jsr:@dprint/automation@0.10.3";
 
 const currentDirPath = $.path(import.meta.dirname!);
 const cargoFilePath = currentDirPath.join("../Cargo.toml");

--- a/scripts/generate_release_notes.ts
+++ b/scripts/generate_release_notes.ts
@@ -1,4 +1,4 @@
-import { generateChangeLog } from "https://raw.githubusercontent.com/dprint/automation/0.10.0/changelog.ts";
+import { generateChangeLog } from "jsr:@dprint/automation@0.10.3";
 
 const version = Deno.args[0];
 const checksum = Deno.args[1];


### PR DESCRIPTION
Because GitHub is unreliable.