### PR TITLE
chore: modernize CI output syntax and add npm install option to README

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -139,62 +139,62 @@ jobs:
         run: |-
           cd target/x86_64-apple-darwin/release
           zip -r dprint-plugin-exec-x86_64-apple-darwin.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-x86_64-apple-darwin.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-x86_64-apple-darwin.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (aarch64-apple-darwin)
         id: pre_release_aarch64_apple_darwin
         if: 'matrix.config.target == ''aarch64-apple-darwin'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           cd target/aarch64-apple-darwin/release
           zip -r dprint-plugin-exec-aarch64-apple-darwin.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-aarch64-apple-darwin.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-aarch64-apple-darwin.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (x86_64-pc-windows-msvc)
         id: pre_release_x86_64_pc_windows_msvc
         if: 'matrix.config.target == ''x86_64-pc-windows-msvc'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           Compress-Archive -CompressionLevel Optimal -Force -Path target/x86_64-pc-windows-msvc/release/dprint-plugin-exec.exe -DestinationPath target/x86_64-pc-windows-msvc/release/dprint-plugin-exec-x86_64-pc-windows-msvc.zip
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-plugin-exec-x86_64-pc-windows-msvc.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-plugin-exec-x86_64-pc-windows-msvc.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (x86_64-unknown-linux-gnu)
         id: pre_release_x86_64_unknown_linux_gnu
         if: 'matrix.config.target == ''x86_64-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           cd target/x86_64-unknown-linux-gnu/release
           zip -r dprint-plugin-exec-x86_64-unknown-linux-gnu.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-x86_64-unknown-linux-gnu.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-x86_64-unknown-linux-gnu.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (x86_64-unknown-linux-musl)
         id: pre_release_x86_64_unknown_linux_musl
         if: 'matrix.config.target == ''x86_64-unknown-linux-musl'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           cd target/x86_64-unknown-linux-musl/release
           zip -r dprint-plugin-exec-x86_64-unknown-linux-musl.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-x86_64-unknown-linux-musl.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-x86_64-unknown-linux-musl.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (aarch64-unknown-linux-gnu)
         id: pre_release_aarch64_unknown_linux_gnu
         if: 'matrix.config.target == ''aarch64-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           cd target/aarch64-unknown-linux-gnu/release
           zip -r dprint-plugin-exec-aarch64-unknown-linux-gnu.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-aarch64-unknown-linux-gnu.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-aarch64-unknown-linux-gnu.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (aarch64-unknown-linux-musl)
         id: pre_release_aarch64_unknown_linux_musl
         if: 'matrix.config.target == ''aarch64-unknown-linux-musl'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           cd target/aarch64-unknown-linux-musl/release
           zip -r dprint-plugin-exec-aarch64-unknown-linux-musl.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-aarch64-unknown-linux-musl.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-aarch64-unknown-linux-musl.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (riscv64gc-unknown-linux-gnu)
         id: pre_release_riscv64gc_unknown_linux_gnu
         if: 'matrix.config.target == ''riscv64gc-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           cd target/riscv64gc-unknown-linux-gnu/release
           zip -r dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (loongarch64-unknown-linux-gnu)
         id: pre_release_loongarch64_unknown_linux_gnu
         if: 'matrix.config.target == ''loongarch64-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           cd target/loongarch64-unknown-linux-gnu/release
           zip -r dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip dprint-plugin-exec
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip | awk '{print $1}')"
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Upload artifacts (x86_64-apple-darwin)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: 'matrix.config.target == ''x86_64-apple-darwin'' && startsWith(github.ref, ''refs/tags/'')'
@@ -294,10 +294,10 @@ jobs:
         run: deno run --allow-read=. --allow-write=. scripts/create_plugin_file.ts
       - name: Get tag version
         id: get_tag_version
-        run: 'echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}'
+        run: 'echo "TAG_VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"'
       - name: Get plugin file checksum
         id: get_plugin_file_checksum
-        run: 'echo "::set-output name=CHECKSUM::$(shasum -a 256 plugin.json | awk ''{print $1}'')"'
+        run: 'echo "CHECKSUM=$(shasum -a 256 plugin.json | awk ''{print $1}'')" >> "$GITHUB_OUTPUT"'
       - name: Update Config Schema Version
         run: 'sed -i ''s/exec\/0.0.0/exec\/${{ steps.get_tag_version.outputs.TAG_VERSION }}/'' deployment/schema.json'
       - name: Build npm packages

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -87,12 +87,12 @@ const preReleaseSteps = profiles.map((profile) => {
         return [
           `cd target/${profile.target}/release`,
           `zip -r ${profile.zipFileName} dprint-plugin-exec`,
-          `echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 ${profile.zipFileName} | awk '{print $1}')"`,
+          `echo "ZIP_CHECKSUM=$(shasum -a 256 ${profile.zipFileName} | awk '{print $1}')" >> "$GITHUB_OUTPUT"`,
         ];
       case OperatingSystem.Windows:
         return [
           `Compress-Archive -CompressionLevel Optimal -Force -Path target/${profile.target}/release/dprint-plugin-exec.exe -DestinationPath target/${profile.target}/release/${profile.zipFileName}`,
-          `echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/${profile.target}/release/${profile.zipFileName} | awk '{print $1}')"`,
+          `echo "ZIP_CHECKSUM=$(shasum -a 256 target/${profile.target}/release/${profile.zipFileName} | awk '{print $1}')" >> "$GITHUB_OUTPUT"`,
         ];
     }
   }
@@ -235,14 +235,14 @@ const buildJob = job("build", {
 const getTagVersion = step({
   id: "get_tag_version",
   name: "Get tag version",
-  run: "echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\\/tags\\//}",
+  run: "echo \"TAG_VERSION=${GITHUB_REF/refs\\/tags\\//}\" >> \"$GITHUB_OUTPUT\"",
   outputs: ["TAG_VERSION"],
 });
 
 const getPluginFileChecksum = step({
   id: "get_plugin_file_checksum",
   name: "Get plugin file checksum",
-  run: `echo "::set-output name=CHECKSUM::$(shasum -a 256 plugin.json | awk '{print $1}')"`,
+  run: `echo "CHECKSUM=$(shasum -a 256 plugin.json | awk '{print $1}')" >> "$GITHUB_OUTPUT"`,
   outputs: ["CHECKSUM"],
 });
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin executes CLI commands to format code via stdin (recommended) or via 
 1. Install [dprint](https://dprint.dev/install/)
 2. `dprint init`
 3. `dprint add exec`
+   - Or install from npm: `dprint add npm:@dprint/exec`
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Replace the deprecated `echo ::set-output name=X::Y` syntax with the modern `echo "X=Y" >> "$GITHUB_OUTPUT"` form across `TAG_VERSION`, `CHECKSUM`, and the per-target `ZIP_CHECKSUM` steps in `ci.ts`. Regenerate `ci.generated.yml`.
- Add `dprint add npm:@dprint/exec` as an install option in the README.

## Test plan
- [x] CI passes on this branch.