### PR TITLE
feat: add setupCommand to run a command once before formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Command config:
 - `stdin` - If the text should be provided via stdin (default: `true`)
 - `cwd` - Current working directory to use when launching this command (default: dprint's cwd or the root `cwd` setting if set)
 - `cacheKeyFiles` - A list of paths (relative to `cwd`) to files used to automatically compute a `cacheKey`. This allows automatic invalidation of dprint's incremental cache when any of these files are changed.
+- `setupCommand` - Command to run a single time before this command formats its first file. It runs to completion before any formatting starts, which is useful for one-time setup that would otherwise race when formatting in parallel (ex. installing a toolchain). It is only run when a file actually matches this command, runs in the command's `cwd`, is subject to the same `timeout`, and is not run if formatting is cancelled. It does not support command templates.
 
 Command templates (ex. see the prettier example above):
 
@@ -124,6 +125,32 @@ Use the `rustfmt` binary so you can format stdin.
       "command": "rustfmt --edition 2024",
       "exts": ["rs"],
       // add the config files for automatic cache invalidation when the rust version or rustfmt config changes
+      "cacheKeyFiles": [
+        "rustfmt.toml",
+        "rust-toolchain.toml",
+      ],
+    }],
+  },
+  "plugins": [
+    // run `dprint config add exec` to add the latest exec plugin's url here
+  ],
+}
+```
+
+### Example - rustfmt with a pinned nightly toolchain
+
+When running `rustfmt` through `rustup` with a toolchain that isn't installed yet, `rustup` will try to install it on the fly. Because dprint formats files in parallel, multiple installs can race and fail. Use `setupCommand` to install the toolchain a single time before formatting begins.
+
+```jsonc
+{
+  // ...etc...
+  "exec": {
+    "cwd": "${configDir}",
+    "commands": [{
+      "command": "rustup run nightly-2025-09-01 rustfmt --edition 2024",
+      // installs the toolchain once before formatting the first file
+      "setupCommand": "rustup toolchain install nightly-2025-09-01",
+      "exts": ["rs"],
       "cacheKeyFiles": [
         "rustfmt.toml",
         "rust-toolchain.toml",

--- a/README.md
+++ b/README.md
@@ -137,32 +137,6 @@ Use the `rustfmt` binary so you can format stdin.
 }
 ```
 
-### Example - rustfmt with a pinned nightly toolchain
-
-When running `rustfmt` through `rustup` with a toolchain that isn't installed yet, `rustup` will try to install it on the fly. Because dprint formats files in parallel, multiple installs can race and fail. Use `setupCommand` to install the toolchain a single time before formatting begins.
-
-```jsonc
-{
-  // ...etc...
-  "exec": {
-    "cwd": "${configDir}",
-    "commands": [{
-      "command": "rustup run nightly-2025-09-01 rustfmt --edition 2024",
-      // installs the toolchain once before formatting the first file
-      "setupCommand": "rustup toolchain install nightly-2025-09-01",
-      "exts": ["rs"],
-      "cacheKeyFiles": [
-        "rustfmt.toml",
-        "rust-toolchain.toml",
-      ],
-    }],
-  },
-  "plugins": [
-    // run `dprint config add exec` to add the latest exec plugin's url here
-  ],
-}
-```
-
 ### Example - prettier
 
 Consider using [dprint-plugin-prettier](https://dprint.dev/plugins/prettier/) instead as it will be much faster.

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -45,6 +45,18 @@ pub struct CommandConfiguration {
   pub file_extensions: Vec<String>,
   pub file_names: Vec<String>,
   pub cache_key_files_hash: Option<String>,
+  /// Command to run once before this command formats its first file.
+  pub setup_command: Option<SetupCommand>,
+}
+
+/// A command run a single time before formatting begins (ex. to install a
+/// toolchain so that parallel formatting doesn't race installing it).
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupCommand {
+  pub executable: String,
+  /// Executable arguments to add
+  pub args: Vec<String>,
 }
 
 impl CommandConfiguration {
@@ -261,9 +273,12 @@ fn parse_command_obj(
     }
   };
 
+  let setup_command = parse_setup_command(&mut command_obj, &mut diagnostics);
+
   let config = CommandConfiguration {
     executable: command.remove(0),
     args: command,
+    setup_command,
     associations: {
       let maybe_value = command_obj.swap_remove("associations").and_then(|value| match value {
         ConfigKeyValue::String(value) => Some(value),
@@ -342,6 +357,29 @@ fn parse_command_obj(
   }
 
   (Some(config), diagnostics)
+}
+
+fn parse_setup_command(
+  command_obj: &mut ConfigKeyMap,
+  diagnostics: &mut Vec<ConfigurationDiagnostic>,
+) -> Option<SetupCommand> {
+  let raw = get_nullable_value::<String>(command_obj, "setupCommand", diagnostics)?;
+  let mut parts = splitty::split_unquoted_whitespace(&raw)
+    .unwrap_quotes(true)
+    .filter(|p| !p.is_empty())
+    .map(String::from)
+    .collect::<Vec<_>>();
+  if parts.is_empty() {
+    diagnostics.push(ConfigurationDiagnostic {
+      property_name: "setupCommand".to_string(),
+      message: "Expected to find a command name.".to_string(),
+    });
+    return None;
+  }
+  Some(SetupCommand {
+    executable: parts.remove(0),
+    args: parts,
+  })
 }
 
 fn take_string_or_string_vec(
@@ -549,6 +587,43 @@ mod tests {
       vec![ConfigurationDiagnostic {
         property_name: "commands[0].associations".to_string(),
         message: "Expected string or array value.".to_string(),
+      }],
+    );
+  }
+
+  #[test]
+  fn setup_command() {
+    let unresolved_config = parse_config(json!({
+      "commands": [{
+        "command": "command",
+        "exts": ["txt"],
+        "setupCommand": "rustup toolchain install nightly-2025-09-01",
+      }],
+    }));
+    let result = Configuration::resolve(unresolved_config, &Default::default());
+    assert!(result.diagnostics.is_empty());
+    let setup = result.config.commands[0].setup_command.as_ref().unwrap();
+    assert_eq!(setup.executable, "rustup");
+    assert_eq!(
+      setup.args,
+      vec!["toolchain", "install", "nightly-2025-09-01"]
+    );
+  }
+
+  #[test]
+  fn setup_command_empty() {
+    let unresolved_config = parse_config(json!({
+      "commands": [{
+        "command": "command",
+        "exts": ["txt"],
+        "setupCommand": "",
+      }],
+    }));
+    run_diagnostics_test(
+      unresolved_config,
+      vec![ConfigurationDiagnostic {
+        property_name: "commands[0].setupCommand".to_string(),
+        message: "Expected to find a command name.".to_string(),
       }],
     );
   }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,6 @@
 use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::io::Write;
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -7,6 +9,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::process::ExitStatus;
 use std::process::Stdio;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -29,12 +32,14 @@ use dprint_core::plugins::PluginResolveConfigurationResult;
 use handlebars::Handlebars;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::OnceCell;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::oneshot::Sender;
 
 use crate::configuration::CommandConfiguration;
 use crate::configuration::Configuration;
+use crate::configuration::SetupCommand;
 
 struct ChildKillOnDrop(std::process::Child);
 
@@ -58,7 +63,12 @@ impl DerefMut for ChildKillOnDrop {
   }
 }
 
-pub struct ExecHandler;
+#[derive(Default)]
+pub struct ExecHandler {
+  /// Tracks setup commands that have already run so they only run once
+  /// for the lifetime of the process, even while formatting in parallel.
+  setup_state: SetupState,
+}
 
 #[async_trait(?Send)]
 impl AsyncPluginHandler for ExecHandler {
@@ -129,6 +139,7 @@ impl AsyncPluginHandler for ExecHandler {
       request.file_bytes,
       request.config,
       request.token.clone(),
+      &self.setup_state,
     )
     .await
   }
@@ -139,6 +150,7 @@ pub async fn format_bytes(
   original_file_bytes: Vec<u8>,
   config: Arc<Configuration>,
   token: Arc<dyn CancellationToken>,
+  setup_state: &SetupState,
 ) -> FormatResult {
   fn trim_bytes_len(bytes: &[u8]) -> usize {
     let mut start = 0;
@@ -161,6 +173,17 @@ pub async fn format_bytes(
 
   let mut file_bytes: Cow<Vec<u8>> = Cow::Borrowed(&original_file_bytes);
   for command in select_commands(&config, &file_path)? {
+    // run the command's setup once before formatting with it for the first time
+    if let Some(setup_command) = &command.setup_command {
+      match setup_state
+        .run_once(&command.cwd, setup_command, &config, &token)
+        .await?
+      {
+        SetupRun::Completed => {}
+        SetupRun::Cancelled => return Ok(None),
+      }
+    }
+
     // format here
     let args = maybe_substitute_variables(&file_path, &config, command);
 
@@ -322,6 +345,125 @@ fn timeout_err(config: &Configuration) -> Error {
   )
 }
 
+/// Remembers which setup commands have already been run so that a command's
+/// `setupCommand` only runs a single time, even when many files are being
+/// formatted in parallel (see https://github.com/dprint/dprint/issues/1023).
+#[derive(Default, Clone)]
+pub struct SetupState {
+  cells: Rc<RefCell<HashMap<String, Rc<OnceCell<()>>>>>,
+}
+
+enum SetupRun {
+  Completed,
+  Cancelled,
+}
+
+enum SetupInitError {
+  Cancelled,
+  Failed(Error),
+}
+
+impl SetupState {
+  async fn run_once(
+    &self,
+    cwd: &Path,
+    setup_command: &SetupCommand,
+    config: &Configuration,
+    token: &Arc<dyn CancellationToken>,
+  ) -> Result<SetupRun> {
+    // the cwd is part of the key because the same command run in different
+    // directories may produce different results
+    let key = format!(
+      "{}\0{} {}",
+      cwd.display(),
+      setup_command.executable,
+      setup_command.args.join(" ")
+    );
+    let cell = {
+      let mut cells = self.cells.borrow_mut();
+      cells.entry(key).or_default().clone()
+    };
+    // get_or_try_init ensures only one caller runs the setup at a time and that
+    // the others wait for it to finish; a failure is not cached so it can be
+    // retried by the next file rather than poisoning all formatting
+    match cell
+      .get_or_try_init(|| run_setup_command(cwd, setup_command, config, token))
+      .await
+    {
+      Ok(()) => Ok(SetupRun::Completed),
+      Err(SetupInitError::Cancelled) => Ok(SetupRun::Cancelled),
+      Err(SetupInitError::Failed(err)) => Err(err),
+    }
+  }
+}
+
+async fn run_setup_command(
+  cwd: &Path,
+  setup_command: &SetupCommand,
+  config: &Configuration,
+  token: &Arc<dyn CancellationToken>,
+) -> Result<(), SetupInitError> {
+  let mut child = ChildKillOnDrop(
+    Command::new(&setup_command.executable)
+      .current_dir(cwd)
+      .stdin(Stdio::null())
+      // a plugin must not write to stdout (it's the protocol channel)
+      .stdout(Stdio::null())
+      .stderr(Stdio::piped())
+      .args(&setup_command.args)
+      .spawn()
+      .map_err(|e| SetupInitError::Failed(anyhow!("Cannot start setup command process: {}", e)))?,
+  );
+
+  // capture stderr to surface it if the command fails
+  let (err_tx, err_rx) = oneshot::channel();
+  let mut handles = Vec::with_capacity(1);
+  if let Some(stderr) = child.stderr.take() {
+    handles.push(dprint_core::async_runtime::spawn_blocking(|| {
+      read_stream_lines(stderr, err_tx)
+    }));
+  }
+
+  let child_completed = dprint_core::async_runtime::spawn_blocking(move || {
+    child
+      .wait()
+      .map_err(|e| anyhow!("Error while waiting for setup command to complete: {}", e))
+  });
+
+  let result_future = async {
+    let handles_future = dprint_core::async_runtime::future::join_all(handles);
+    let (child_rs, handle_results) = tokio::join!(child_completed, handles_future);
+    let exit_status = child_rs??;
+    for handle_result in handle_results {
+      handle_result??; // surface any errors capturing
+    }
+    Ok::<_, Error>(exit_status)
+  };
+
+  tokio::select! {
+    _ = token.wait_cancellation() => Err(SetupInitError::Cancelled),
+    _ = tokio::time::sleep(Duration::from_secs(config.timeout as u64)) => {
+      Err(SetupInitError::Failed(anyhow!(
+        "Setup command has not returned a result within {} seconds.",
+        config.timeout,
+      )))
+    }
+    result = result_future => match result {
+      Ok(exit_status) if exit_status.success() => Ok(()),
+      Ok(exit_status) => Err(SetupInitError::Failed(anyhow!(
+        "Setup command '{}' exited with code {}: {}",
+        setup_command.executable,
+        exit_status
+          .code()
+          .map(|code| code.to_string())
+          .unwrap_or_else(|| "unknown".to_string()),
+        String::from_utf8_lossy(&err_rx.await.unwrap_or_default())
+      ))),
+      Err(err) => Err(SetupInitError::Failed(err)),
+    }
+  }
+}
+
 fn read_stream_lines<R>(mut readable: R, sender: Sender<Vec<u8>>) -> Result<(), Error>
 where
   R: std::io::Read + Unpin,
@@ -376,6 +518,7 @@ mod test {
 
   use dprint_core::plugins::NullCancellationToken;
 
+  use super::SetupState;
   use crate::configuration::Configuration;
   use crate::format_bytes;
 
@@ -395,6 +538,7 @@ mod test {
       "1".repeat(101).into_bytes(),
       Arc::new(config),
       token,
+      &SetupState::default(),
     )
     .await;
     let err_text = result.err().unwrap().to_string();
@@ -406,5 +550,52 @@ mod test {
         "Perhaps dprint-plugin-exec has been misconfigured?"
       )
     )
+  }
+
+  #[tokio::test]
+  async fn runs_setup_command_once_across_formats() {
+    // forward slashes work cross-platform for these tools and avoid splitty
+    // treating backslashes in Windows paths as escapes
+    fn to_arg(path: &std::path::Path) -> String {
+      path.to_string_lossy().replace('\\', "/")
+    }
+
+    let marker = std::env::temp_dir().join(format!(
+      "dprint-exec-setup-marker-{}.txt",
+      std::process::id()
+    ));
+    let _ = std::fs::remove_file(&marker);
+    let script = std::env::current_dir()
+      .unwrap()
+      .join("tests/resources/append-marker.js");
+
+    let unresolved_config = serde_json::json!({
+      "commands": [{
+        "command": "deno run -A ./tests/fold.ts -w 30",
+        "setupCommand": format!("deno run -A {} {}", to_arg(&script), to_arg(&marker)),
+        "exts": ["txt"]
+      }]
+    });
+    let unresolved_config = serde_json::from_value(unresolved_config).unwrap();
+    let config = Arc::new(Configuration::resolve(unresolved_config, &Default::default()).config);
+    let setup_state = SetupState::default();
+
+    // format two different files sharing the same setup state
+    for file_name in ["a.txt", "b.txt"] {
+      let result = format_bytes(
+        PathBuf::from(file_name),
+        b"hello world".to_vec(),
+        config.clone(),
+        Arc::new(NullCancellationToken),
+        &setup_state,
+      )
+      .await;
+      assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    // the setup command should have run exactly once
+    let marker_contents = std::fs::read_to_string(&marker).unwrap();
+    let _ = std::fs::remove_file(&marker);
+    assert_eq!(marker_contents, "x");
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,6 @@ fn main() -> Result<()> {
       start_parent_process_checker_task(parent_process_id);
     }
 
-    handle_process_stdio_messages(ExecHandler).await
+    handle_process_stdio_messages(ExecHandler::default()).await
   })
 }

--- a/tests/resources/append-marker.js
+++ b/tests/resources/append-marker.js
@@ -1,0 +1,5 @@
+// appends a single byte to the file path given as the first argument.
+// used by tests to count how many times a setup command runs.
+import { appendFileSync } from "node:fs";
+
+appendFileSync(Deno.args[0], "x");

--- a/tests/specs/General/SetupCommand.txt
+++ b/tests/specs/General/SetupCommand.txt
@@ -1,0 +1,14 @@
+~~ {
+  "lineWidth": 30,
+  "commands": [{
+    "command": "deno run -A ./tests/fold.ts -w 30",
+    "setupCommand": "deno eval 'Deno.exit(0)'",
+    "exts": "txt"
+  }]
+} ~~
+== runs the setup command then formats normally ==
+this should be wrapped because it is a long text
+
+[expect]
+this should be wrapped because
+it is a long text

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,6 +49,7 @@ fn test_specs() {
           file_text.into_bytes(),
           Arc::new(config_result.config),
           Arc::new(dprint_core::plugins::NullCancellationToken),
+          &dprint_plugin_exec::handler::SetupState::default(),
         )
         .await
         .map(|maybe_bytes| maybe_bytes.map(|bytes| String::from_utf8(bytes).unwrap()))


### PR DESCRIPTION
Adds a per-command `setupCommand` option that runs a single time before the command formats its first file. It runs to completion before any formatting begins, which avoids races when many files are formatted in parallel (ex. installing a toolchain via rustup).

Closes dprint/dprint#1023