### PR TITLE
feat: add powerpc64le builds

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -24,38 +24,57 @@ jobs:
             run_tests: 'true'
             target: x86_64-apple-darwin
             cross: 'false'
+            musl_image: ''
           - os: macos-latest
             run_tests: 'true'
             target: aarch64-apple-darwin
             cross: 'false'
+            musl_image: ''
           - os: windows-latest
             run_tests: 'true'
             target: x86_64-pc-windows-msvc
             cross: 'false'
+            musl_image: ''
           - os: ubuntu-22.04
             run_tests: 'true'
             target: x86_64-unknown-linux-gnu
             cross: 'false'
+            musl_image: ''
           - os: ubuntu-22.04
             run_tests: 'false'
             target: x86_64-unknown-linux-musl
             cross: 'false'
+            musl_image: ''
           - os: ubuntu-22.04
             run_tests: 'false'
             target: aarch64-unknown-linux-gnu
             cross: 'false'
+            musl_image: ''
           - os: ubuntu-22.04
             run_tests: 'false'
             target: aarch64-unknown-linux-musl
             cross: 'false'
+            musl_image: ''
           - os: ubuntu-22.04
             run_tests: 'false'
             target: riscv64gc-unknown-linux-gnu
             cross: 'true'
+            musl_image: ''
           - os: ubuntu-22.04
             run_tests: 'false'
             target: loongarch64-unknown-linux-gnu
             cross: 'true'
+            musl_image: ''
+          - os: ubuntu-22.04
+            run_tests: 'false'
+            target: powerpc64le-unknown-linux-gnu
+            cross: 'true'
+            musl_image: ''
+          - os: ubuntu-22.04
+            run_tests: 'false'
+            target: powerpc64le-unknown-linux-musl
+            cross: 'false'
+            musl_image: 'ghcr.io/rust-cross/rust-musl-cross:powerpc64le-musl'
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: full
@@ -69,6 +88,8 @@ jobs:
       ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL: '${{ steps.pre_release_aarch64_unknown_linux_musl.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU: '${{ steps.pre_release_riscv64gc_unknown_linux_gnu.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU: '${{ steps.pre_release_loongarch64_unknown_linux_gnu.outputs.ZIP_CHECKSUM }}'
+      ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_GNU: '${{ steps.pre_release_powerpc64le_unknown_linux_gnu.outputs.ZIP_CHECKSUM }}'
+      ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_MUSL: '${{ steps.pre_release_powerpc64le_unknown_linux_musl.outputs.ZIP_CHECKSUM }}'
     steps:
       - name: Prepare git
         run: |-
@@ -104,12 +125,12 @@ jobs:
         if: matrix.config.cross == 'true'
         run: 'cargo install cross --git https://github.com/cross-rs/cross --rev 4090beca3cfffa44371a5bba524de3a578aa46c3'
       - name: Build (Debug)
-        if: 'matrix.config.cross != ''true'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: 'matrix.config.cross != ''true'' && matrix.config.musl_image == '''' && !startsWith(github.ref, ''refs/tags/'')'
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: 'cargo build --locked --all-targets --target ${{matrix.config.target}}'
       - name: Build release
-        if: 'matrix.config.cross != ''true'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'matrix.config.cross != ''true'' && matrix.config.musl_image == '''' && startsWith(github.ref, ''refs/tags/'')'
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: 'cargo build --locked --all-targets --target ${{matrix.config.target}} --release'
@@ -119,6 +140,16 @@ jobs:
       - name: Build cross (Release)
         if: 'matrix.config.cross == ''true'' && startsWith(github.ref, ''refs/tags/'')'
         run: 'cross build --locked --target ${{matrix.config.target}} --release'
+      - name: Build musl image (Debug)
+        if: 'matrix.config.musl_image != '''' && !startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src ${{matrix.config.musl_image}} cargo build --locked --target ${{matrix.config.target}}
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"
+      - name: Build musl image (Release)
+        if: 'matrix.config.musl_image != '''' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src ${{matrix.config.musl_image}} cargo build --locked --target ${{matrix.config.target}} --release
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"
       - name: Lint
         if: '!startsWith(github.ref, ''refs/tags/'') && matrix.config.target == ''x86_64-unknown-linux-gnu'''
         run: cargo clippy
@@ -195,6 +226,20 @@ jobs:
           cd target/loongarch64-unknown-linux-gnu/release
           zip -r dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip dprint-plugin-exec
           echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Pre-release (powerpc64le-unknown-linux-gnu)
+        id: pre_release_powerpc64le_unknown_linux_gnu
+        if: 'matrix.config.target == ''powerpc64le-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          cd target/powerpc64le-unknown-linux-gnu/release
+          zip -r dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip dprint-plugin-exec
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Pre-release (powerpc64le-unknown-linux-musl)
+        id: pre_release_powerpc64le_unknown_linux_musl
+        if: 'matrix.config.target == ''powerpc64le-unknown-linux-musl'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          cd target/powerpc64le-unknown-linux-musl/release
+          zip -r dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip dprint-plugin-exec
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Upload artifacts (x86_64-apple-darwin)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: 'matrix.config.target == ''x86_64-apple-darwin'' && startsWith(github.ref, ''refs/tags/'')'
@@ -249,6 +294,18 @@ jobs:
         with:
           name: loongarch64-unknown-linux-gnu-artifacts
           path: target/loongarch64-unknown-linux-gnu/release/dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip
+      - name: Upload artifacts (powerpc64le-unknown-linux-gnu)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: 'matrix.config.target == ''powerpc64le-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
+        with:
+          name: powerpc64le-unknown-linux-gnu-artifacts
+          path: target/powerpc64le-unknown-linux-gnu/release/dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip
+      - name: Upload artifacts (powerpc64le-unknown-linux-musl)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: 'matrix.config.target == ''powerpc64le-unknown-linux-musl'' && startsWith(github.ref, ''refs/tags/'')'
+        with:
+          name: powerpc64le-unknown-linux-musl-artifacts
+          path: target/powerpc64le-unknown-linux-musl/release/dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip
   draft_release:
     name: draft_release
     needs:
@@ -279,6 +336,8 @@ jobs:
           mv aarch64-unknown-linux-musl-artifacts/dprint-plugin-exec-aarch64-unknown-linux-musl.zip .
           mv riscv64gc-unknown-linux-gnu-artifacts/dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip .
           mv loongarch64-unknown-linux-gnu-artifacts/dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip .
+          mv powerpc64le-unknown-linux-gnu-artifacts/dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip .
+          mv powerpc64le-unknown-linux-musl-artifacts/dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip .
       - name: Output checksums
         run: |-
           echo "dprint-plugin-exec-x86_64-apple-darwin.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_X86_64_APPLE_DARWIN }}"
@@ -290,6 +349,8 @@ jobs:
           echo "dprint-plugin-exec-aarch64-unknown-linux-musl.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL }}"
           echo "dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU }}"
           echo "dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU }}"
+          echo "dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_GNU }}"
+          echo "dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_MUSL }}"
       - name: Create plugin file
         run: deno run --allow-read=. --allow-write=. scripts/create_plugin_file.ts
       - name: Get tag version
@@ -319,6 +380,8 @@ jobs:
             dprint-plugin-exec-aarch64-unknown-linux-musl.zip
             dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip
             dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip
+            dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip
+            dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip
             plugin.json
             deployment/schema.json
           body_path: '${{ github.workspace }}-CHANGELOG.txt'

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -143,12 +143,12 @@ jobs:
       - name: Build musl image (Debug)
         if: 'matrix.config.musl_image != '''' && !startsWith(github.ref, ''refs/tags/'')'
         run: |-
-          docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src ${{matrix.config.musl_image}} cargo build --locked --target ${{matrix.config.target}}
+          docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src ${{matrix.config.musl_image}} bash -c "rustup target add ${{matrix.config.target}} && cargo build --locked --target ${{matrix.config.target}}"
           sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"
       - name: Build musl image (Release)
         if: 'matrix.config.musl_image != '''' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
-          docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src ${{matrix.config.musl_image}} cargo build --locked --target ${{matrix.config.target}} --release
+          docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src ${{matrix.config.musl_image}} bash -c "rustup target add ${{matrix.config.target}} && cargo build --locked --target ${{matrix.config.target}} --release"
           sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"
       - name: Lint
         if: '!startsWith(github.ref, ''refs/tags/'') && matrix.config.target == ''x86_64-unknown-linux-gnu'''

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -13,6 +13,12 @@ interface ProfileData {
   target: string;
   cross?: boolean;
   runTests?: boolean;
+  /**
+   * Build by running cargo directly inside this Docker image. Used for targets
+   * cross doesn't provide an image for (e.g. powerpc64le musl), where the image
+   * already bundles the toolchain.
+   */
+  muslCrossImage?: string;
 }
 
 const profileDataItems: ProfileData[] = [{
@@ -48,6 +54,17 @@ const profileDataItems: ProfileData[] = [{
   os: OperatingSystem.Linux,
   cross: true,
   target: "loongarch64-unknown-linux-gnu",
+}, {
+  // ppc64le: built with cross, which provides an image for this target.
+  os: OperatingSystem.Linux,
+  cross: true,
+  target: "powerpc64le-unknown-linux-gnu",
+}, {
+  // cross has no powerpc64le musl image, so build directly in the prebuilt
+  // rust-musl-cross toolchain image instead (see the "Build musl image" steps).
+  os: OperatingSystem.Linux,
+  target: "powerpc64le-unknown-linux-musl",
+  muslCrossImage: "ghcr.io/rust-cross/rust-musl-cross:powerpc64le-musl",
 }];
 
 const profiles = profileDataItems.map((profile) => {
@@ -65,18 +82,22 @@ const matrix = defineMatrix({
     run_tests: (profile.runTests ?? false).toString(),
     target: profile.target,
     cross: (profile.cross ?? false).toString(),
+    musl_image: profile.muslCrossImage ?? "",
   })),
 });
 
 const target = expr("matrix.config.target");
 const os = expr("matrix.config.os");
 const cross = expr("matrix.config.cross");
+const muslImage = expr("matrix.config.musl_image");
 const runTests = expr("matrix.config.run_tests");
 
 const isTag = conditions.isTag();
 const isNotTag = isTag.not();
 const isCross = cross.equals("true");
 const isNotCross = cross.notEquals("true");
+const isMuslImage = muslImage.notEquals("");
+const isNotMuslImage = muslImage.equals("");
 
 const preReleaseSteps = profiles.map((profile) => {
   function getRunSteps() {
@@ -172,7 +193,7 @@ const buildJob = job("build", {
     },
     {
       name: "Build (Debug)",
-      if: isNotCross.and(isNotTag),
+      if: isNotCross.and(isNotMuslImage).and(isNotTag),
       env: {
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc",
       },
@@ -180,7 +201,7 @@ const buildJob = job("build", {
     },
     {
       name: "Build release",
-      if: isNotCross.and(isTag),
+      if: isNotCross.and(isNotMuslImage).and(isTag),
       env: {
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc",
       },
@@ -195,6 +216,27 @@ const buildJob = job("build", {
       name: "Build cross (Release)",
       if: isCross.and(isTag),
       run: "cross build --locked --target ${{matrix.config.target}} --release",
+    },
+    {
+      // build inside the rust-musl-cross image, which bundles the toolchain and
+      // runs as root, so it can install the pinned toolchain into its own
+      // /root/.rustup -- the reason this can't go through cross, which runs as
+      // the non-root host user. The output is chown'd back so later steps can
+      // read and zip it.
+      name: "Build musl image (Debug)",
+      if: isMuslImage.and(isNotTag),
+      run: [
+        `docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src \${{matrix.config.musl_image}} cargo build --locked --target \${{matrix.config.target}}`,
+        `sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"`,
+      ],
+    },
+    {
+      name: "Build musl image (Release)",
+      if: isMuslImage.and(isTag),
+      run: [
+        `docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src \${{matrix.config.musl_image}} cargo build --locked --target \${{matrix.config.target}} --release`,
+        `sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"`,
+      ],
     },
     {
       name: "Lint",

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -218,15 +218,17 @@ const buildJob = job("build", {
       run: "cross build --locked --target ${{matrix.config.target}} --release",
     },
     {
-      // build inside the rust-musl-cross image, which bundles the toolchain and
-      // runs as root, so it can install the pinned toolchain into its own
-      // /root/.rustup -- the reason this can't go through cross, which runs as
-      // the non-root host user. The output is chown'd back so later steps can
-      // read and zip it.
+      // build inside the rust-musl-cross image, which bundles the musl
+      // toolchain and runs as root, so it can install the pinned toolchain into
+      // its own /root/.rustup -- the reason this can't go through cross, which
+      // runs as the non-root host user. `rustup target add` is required because
+      // rust-toolchain.toml pins a channel that rustup installs fresh, without
+      // the target's std (only the image's default toolchain has it baked in).
+      // The output is chown'd back so later steps can read and zip it.
       name: "Build musl image (Debug)",
       if: isMuslImage.and(isNotTag),
       run: [
-        `docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src \${{matrix.config.musl_image}} cargo build --locked --target \${{matrix.config.target}}`,
+        `docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src \${{matrix.config.musl_image}} bash -c "rustup target add \${{matrix.config.target}} && cargo build --locked --target \${{matrix.config.target}}"`,
         `sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"`,
       ],
     },
@@ -234,7 +236,7 @@ const buildJob = job("build", {
       name: "Build musl image (Release)",
       if: isMuslImage.and(isTag),
       run: [
-        `docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src \${{matrix.config.musl_image}} cargo build --locked --target \${{matrix.config.target}} --release`,
+        `docker run --rm -v "$GITHUB_WORKSPACE":/home/rust/src -w /home/rust/src \${{matrix.config.musl_image}} bash -c "rustup target add \${{matrix.config.target}} && cargo build --locked --target \${{matrix.config.target}} --release"`,
         `sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/target"`,
       ],
     },

--- a/scripts/create_npm_packages.ts
+++ b/scripts/create_npm_packages.ts
@@ -1,4 +1,4 @@
-import { $, CargoToml, getChecksum, processPlugin } from "jsr:@dprint/automation@0.11.2";
+import { $, CargoToml, getChecksum, processPlugin } from "jsr:@dprint/automation@0.12.1";
 
 const pluginName = "dprint-plugin-exec";
 const mainPackageName = "@dprint/exec";
@@ -15,6 +15,8 @@ const platforms: processPlugin.Platform[] = [
   "linux-x86_64-musl",
   "linux-riscv64",
   "linux-loongarch64",
+  "linux-powerpc64",
+  "linux-powerpc64-musl",
   "windows-x86_64",
 ];
 

--- a/scripts/create_plugin_file.ts
+++ b/scripts/create_plugin_file.ts
@@ -1,4 +1,4 @@
-import { $, CargoToml, processPlugin } from "jsr:@dprint/automation@0.11.0";
+import { $, CargoToml, processPlugin } from "jsr:@dprint/automation@0.12.1";
 
 const currentDirPath = $.path(import.meta.dirname!);
 const cargoFilePath = currentDirPath.join("../Cargo.toml");
@@ -15,6 +15,8 @@ await processPlugin.createDprintOrgProcessPlugin({
     "linux-x86_64-musl",
     "linux-riscv64",
     "linux-loongarch64",
+    "linux-powerpc64",
+    "linux-powerpc64-musl",
     "windows-x86_64",
   ],
   isTest: Deno.args.some(a => a == "--test"),


### PR DESCRIPTION
Adds the missing powerpc64le architectures.

- `powerpc64le-unknown-linux-gnu` — built with `cross`, which provides an image for this target.
- `powerpc64le-unknown-linux-musl` — `cross` has no musl image, so it's built directly in the prebuilt `rust-musl-cross` toolchain image (runs as root so it can install the pinned toolchain), then the output is `chown`'d back.

Bumps `@dprint/automation` to `0.12.1`, which adds the `linux-powerpc64` / `linux-powerpc64-musl` process plugin platforms. The plugin.json key uses `linux-powerpc64` to match `std::env::consts::ARCH` (which is `powerpc64` for both endian variants), while the zip names and npm `ppc64` mappings keep `powerpc64le`/`ppc64`.