### PR TITLE
feat: add loongarch64-unknown-linux-musl build

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -67,6 +67,11 @@ jobs:
             musl_image: ''
           - os: ubuntu-22.04
             run_tests: 'false'
+            target: loongarch64-unknown-linux-musl
+            cross: 'true'
+            musl_image: ''
+          - os: ubuntu-22.04
+            run_tests: 'false'
             target: powerpc64le-unknown-linux-gnu
             cross: 'true'
             musl_image: ''
@@ -88,6 +93,7 @@ jobs:
       ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL: '${{ steps.pre_release_aarch64_unknown_linux_musl.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU: '${{ steps.pre_release_riscv64gc_unknown_linux_gnu.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU: '${{ steps.pre_release_loongarch64_unknown_linux_gnu.outputs.ZIP_CHECKSUM }}'
+      ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL: '${{ steps.pre_release_loongarch64_unknown_linux_musl.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_GNU: '${{ steps.pre_release_powerpc64le_unknown_linux_gnu.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_MUSL: '${{ steps.pre_release_powerpc64le_unknown_linux_musl.outputs.ZIP_CHECKSUM }}'
     steps:
@@ -226,6 +232,13 @@ jobs:
           cd target/loongarch64-unknown-linux-gnu/release
           zip -r dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip dprint-plugin-exec
           echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Pre-release (loongarch64-unknown-linux-musl)
+        id: pre_release_loongarch64_unknown_linux_musl
+        if: 'matrix.config.target == ''loongarch64-unknown-linux-musl'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          cd target/loongarch64-unknown-linux-musl/release
+          zip -r dprint-plugin-exec-loongarch64-unknown-linux-musl.zip dprint-plugin-exec
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-loongarch64-unknown-linux-musl.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Pre-release (powerpc64le-unknown-linux-gnu)
         id: pre_release_powerpc64le_unknown_linux_gnu
         if: 'matrix.config.target == ''powerpc64le-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
@@ -294,6 +307,12 @@ jobs:
         with:
           name: loongarch64-unknown-linux-gnu-artifacts
           path: target/loongarch64-unknown-linux-gnu/release/dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip
+      - name: Upload artifacts (loongarch64-unknown-linux-musl)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: 'matrix.config.target == ''loongarch64-unknown-linux-musl'' && startsWith(github.ref, ''refs/tags/'')'
+        with:
+          name: loongarch64-unknown-linux-musl-artifacts
+          path: target/loongarch64-unknown-linux-musl/release/dprint-plugin-exec-loongarch64-unknown-linux-musl.zip
       - name: Upload artifacts (powerpc64le-unknown-linux-gnu)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: 'matrix.config.target == ''powerpc64le-unknown-linux-gnu'' && startsWith(github.ref, ''refs/tags/'')'
@@ -336,6 +355,7 @@ jobs:
           mv aarch64-unknown-linux-musl-artifacts/dprint-plugin-exec-aarch64-unknown-linux-musl.zip .
           mv riscv64gc-unknown-linux-gnu-artifacts/dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip .
           mv loongarch64-unknown-linux-gnu-artifacts/dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip .
+          mv loongarch64-unknown-linux-musl-artifacts/dprint-plugin-exec-loongarch64-unknown-linux-musl.zip .
           mv powerpc64le-unknown-linux-gnu-artifacts/dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip .
           mv powerpc64le-unknown-linux-musl-artifacts/dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip .
       - name: Output checksums
@@ -349,6 +369,7 @@ jobs:
           echo "dprint-plugin-exec-aarch64-unknown-linux-musl.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL }}"
           echo "dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU }}"
           echo "dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU }}"
+          echo "dprint-plugin-exec-loongarch64-unknown-linux-musl.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL }}"
           echo "dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_GNU }}"
           echo "dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_MUSL }}"
       - name: Create plugin file
@@ -380,6 +401,7 @@ jobs:
             dprint-plugin-exec-aarch64-unknown-linux-musl.zip
             dprint-plugin-exec-riscv64gc-unknown-linux-gnu.zip
             dprint-plugin-exec-loongarch64-unknown-linux-gnu.zip
+            dprint-plugin-exec-loongarch64-unknown-linux-musl.zip
             dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip
             dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip
             plugin.json

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -55,6 +55,10 @@ const profileDataItems: ProfileData[] = [{
   cross: true,
   target: "loongarch64-unknown-linux-gnu",
 }, {
+  os: OperatingSystem.Linux,
+  cross: true,
+  target: "loongarch64-unknown-linux-musl",
+}, {
   // ppc64le: built with cross, which provides an image for this target.
   os: OperatingSystem.Linux,
   cross: true,

--- a/scripts/create_npm_packages.ts
+++ b/scripts/create_npm_packages.ts
@@ -15,6 +15,7 @@ const platforms: processPlugin.Platform[] = [
   "linux-x86_64-musl",
   "linux-riscv64",
   "linux-loongarch64",
+  "linux-loongarch64-musl",
   "linux-powerpc64",
   "linux-powerpc64-musl",
   "windows-x86_64",

--- a/scripts/create_plugin_file.ts
+++ b/scripts/create_plugin_file.ts
@@ -15,6 +15,7 @@ await processPlugin.createDprintOrgProcessPlugin({
     "linux-x86_64-musl",
     "linux-riscv64",
     "linux-loongarch64",
+    "linux-loongarch64-musl",
     "linux-powerpc64",
     "linux-powerpc64-musl",
     "windows-x86_64",


### PR DESCRIPTION
Adds the `loongarch64-unknown-linux-musl` target, the one remaining libc variant missing for loongarch.

- Built with `cross`, which provides an image for this target (the pinned cross rev already supports it) — same simple path as the existing `loongarch64-unknown-linux-gnu` build, no `rust-musl-cross`/docker-run needed.
- Adds the `linux-loongarch64-musl` process plugin platform (`@dprint/automation` 0.12.1 already supports it) and the `@dprint/exec-linux-loong64-musl` npm sub-package.

CI was green for all three new builds (loongarch64-musl + both powerpc64le) when this commit briefly landed on main before being moved here.