### PR TITLE
feat: add android (Termux) builds

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -80,6 +80,16 @@ jobs:
             target: powerpc64le-unknown-linux-musl
             cross: 'false'
             musl_image: 'ghcr.io/rust-cross/rust-musl-cross:powerpc64le-musl'
+          - os: ubuntu-22.04
+            run_tests: 'false'
+            target: aarch64-linux-android
+            cross: 'true'
+            musl_image: ''
+          - os: ubuntu-22.04
+            run_tests: 'false'
+            target: x86_64-linux-android
+            cross: 'true'
+            musl_image: ''
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: full
@@ -96,6 +106,8 @@ jobs:
       ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL: '${{ steps.pre_release_loongarch64_unknown_linux_musl.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_GNU: '${{ steps.pre_release_powerpc64le_unknown_linux_gnu.outputs.ZIP_CHECKSUM }}'
       ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_MUSL: '${{ steps.pre_release_powerpc64le_unknown_linux_musl.outputs.ZIP_CHECKSUM }}'
+      ZIP_CHECKSUM_AARCH64_LINUX_ANDROID: '${{ steps.pre_release_aarch64_linux_android.outputs.ZIP_CHECKSUM }}'
+      ZIP_CHECKSUM_X86_64_LINUX_ANDROID: '${{ steps.pre_release_x86_64_linux_android.outputs.ZIP_CHECKSUM }}'
     steps:
       - name: Prepare git
         run: |-
@@ -253,6 +265,20 @@ jobs:
           cd target/powerpc64le-unknown-linux-musl/release
           zip -r dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip dprint-plugin-exec
           echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Pre-release (aarch64-linux-android)
+        id: pre_release_aarch64_linux_android
+        if: 'matrix.config.target == ''aarch64-linux-android'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          cd target/aarch64-linux-android/release
+          zip -r dprint-plugin-exec-aarch64-linux-android.zip dprint-plugin-exec
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-aarch64-linux-android.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Pre-release (x86_64-linux-android)
+        id: pre_release_x86_64_linux_android
+        if: 'matrix.config.target == ''x86_64-linux-android'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          cd target/x86_64-linux-android/release
+          zip -r dprint-plugin-exec-x86_64-linux-android.zip dprint-plugin-exec
+          echo "ZIP_CHECKSUM=$(shasum -a 256 dprint-plugin-exec-x86_64-linux-android.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Upload artifacts (x86_64-apple-darwin)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: 'matrix.config.target == ''x86_64-apple-darwin'' && startsWith(github.ref, ''refs/tags/'')'
@@ -325,6 +351,18 @@ jobs:
         with:
           name: powerpc64le-unknown-linux-musl-artifacts
           path: target/powerpc64le-unknown-linux-musl/release/dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip
+      - name: Upload artifacts (aarch64-linux-android)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: 'matrix.config.target == ''aarch64-linux-android'' && startsWith(github.ref, ''refs/tags/'')'
+        with:
+          name: aarch64-linux-android-artifacts
+          path: target/aarch64-linux-android/release/dprint-plugin-exec-aarch64-linux-android.zip
+      - name: Upload artifacts (x86_64-linux-android)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: 'matrix.config.target == ''x86_64-linux-android'' && startsWith(github.ref, ''refs/tags/'')'
+        with:
+          name: x86_64-linux-android-artifacts
+          path: target/x86_64-linux-android/release/dprint-plugin-exec-x86_64-linux-android.zip
   draft_release:
     name: draft_release
     needs:
@@ -358,6 +396,8 @@ jobs:
           mv loongarch64-unknown-linux-musl-artifacts/dprint-plugin-exec-loongarch64-unknown-linux-musl.zip .
           mv powerpc64le-unknown-linux-gnu-artifacts/dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip .
           mv powerpc64le-unknown-linux-musl-artifacts/dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip .
+          mv aarch64-linux-android-artifacts/dprint-plugin-exec-aarch64-linux-android.zip .
+          mv x86_64-linux-android-artifacts/dprint-plugin-exec-x86_64-linux-android.zip .
       - name: Output checksums
         run: |-
           echo "dprint-plugin-exec-x86_64-apple-darwin.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_X86_64_APPLE_DARWIN }}"
@@ -372,6 +412,8 @@ jobs:
           echo "dprint-plugin-exec-loongarch64-unknown-linux-musl.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL }}"
           echo "dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_GNU }}"
           echo "dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_POWERPC64LE_UNKNOWN_LINUX_MUSL }}"
+          echo "dprint-plugin-exec-aarch64-linux-android.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_AARCH64_LINUX_ANDROID }}"
+          echo "dprint-plugin-exec-x86_64-linux-android.zip: ${{ needs.build.outputs.ZIP_CHECKSUM_X86_64_LINUX_ANDROID }}"
       - name: Create plugin file
         run: deno run --allow-read=. --allow-write=. scripts/create_plugin_file.ts
       - name: Get tag version
@@ -404,6 +446,8 @@ jobs:
             dprint-plugin-exec-loongarch64-unknown-linux-musl.zip
             dprint-plugin-exec-powerpc64le-unknown-linux-gnu.zip
             dprint-plugin-exec-powerpc64le-unknown-linux-musl.zip
+            dprint-plugin-exec-aarch64-linux-android.zip
+            dprint-plugin-exec-x86_64-linux-android.zip
             plugin.json
             deployment/schema.json
           body_path: '${{ github.workspace }}-CHANGELOG.txt'

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -69,6 +69,16 @@ const profileDataItems: ProfileData[] = [{
   os: OperatingSystem.Linux,
   target: "powerpc64le-unknown-linux-musl",
   muslCrossImage: "ghcr.io/rust-cross/rust-musl-cross:powerpc64le-musl",
+}, {
+  // android (Termux): built with cross using its built-in NDK image. bionic
+  // libc, so there's only the one variant per arch (no gnu/musl split).
+  os: OperatingSystem.Linux,
+  cross: true,
+  target: "aarch64-linux-android",
+}, {
+  os: OperatingSystem.Linux,
+  cross: true,
+  target: "x86_64-linux-android",
 }];
 
 const profiles = profileDataItems.map((profile) => {

--- a/scripts/create_npm_packages.ts
+++ b/scripts/create_npm_packages.ts
@@ -1,4 +1,4 @@
-import { $, CargoToml, getChecksum, processPlugin } from "jsr:@dprint/automation@0.12.1";
+import { $, CargoToml, getChecksum, processPlugin } from "jsr:@dprint/automation@0.12.2";
 
 const pluginName = "dprint-plugin-exec";
 const mainPackageName = "@dprint/exec";
@@ -18,6 +18,8 @@ const platforms: processPlugin.Platform[] = [
   "linux-loongarch64-musl",
   "linux-powerpc64",
   "linux-powerpc64-musl",
+  "android-aarch64",
+  "android-x86_64",
   "windows-x86_64",
 ];
 

--- a/scripts/create_plugin_file.ts
+++ b/scripts/create_plugin_file.ts
@@ -1,4 +1,4 @@
-import { $, CargoToml, processPlugin } from "jsr:@dprint/automation@0.12.1";
+import { $, CargoToml, processPlugin } from "jsr:@dprint/automation@0.12.2";
 
 const currentDirPath = $.path(import.meta.dirname!);
 const cargoFilePath = currentDirPath.join("../Cargo.toml");
@@ -18,6 +18,8 @@ await processPlugin.createDprintOrgProcessPlugin({
     "linux-loongarch64-musl",
     "linux-powerpc64",
     "linux-powerpc64-musl",
+    "android-aarch64",
+    "android-x86_64",
     "windows-x86_64",
   ],
   isTest: Deno.args.some(a => a == "--test"),


### PR DESCRIPTION
Adds `aarch64-linux-android` and `x86_64-linux-android` targets, resolving the Termux request (dprint/dprint#972).

## What changed
`dprint-plugin-exec` is a plain process binary (no embedded wasmer), so this is purely build + distribution wiring — no source changes:

- **`.github/workflows/ci.ts`** — added the two android targets as `cross: true` profiles (cross's built-in NDK images). bionic libc, so there's only one variant per arch (no gnu/musl split). Regenerated `ci.generated.yml`, which fans out into the matrix, pre-release zip steps, upload-artifact steps, build-job checksum outputs, and the draft-release file/checksum lists.
- **`scripts/create_plugin_file.ts`** & **`scripts/create_npm_packages.ts`** — bumped `@dprint/automation` to `0.12.2` and added the `android-aarch64` / `android-x86_64` platforms.

## Notes
- Depends on **`@dprint/automation@0.12.2`** (already published to JSR), which adds the `android-*` `Platform` variants. The platform keys match the runtime keys added to the dprint CLI's process-plugin resolver (`os = "android"` + arch).

## Verification
- Both scripts type-check against the published `@dprint/automation@0.12.2`.
- `dprint check` passes on all changed files.