### PR TITLE
fix: remove timeout from setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Command config:
 - `stdin` - If the text should be provided via stdin (default: `true`)
 - `cwd` - Current working directory to use when launching this command (default: dprint's cwd or the root `cwd` setting if set)
 - `cacheKeyFiles` - A list of paths (relative to `cwd`) to files used to automatically compute a `cacheKey`. This allows automatic invalidation of dprint's incremental cache when any of these files are changed.
-- `setupCommand` - Command to run a single time before this command formats its first file. It runs to completion before any formatting starts, which is useful for one-time setup that would otherwise race when formatting in parallel (ex. installing a toolchain). It is only run when a file actually matches this command, runs in the command's `cwd`, is subject to the same `timeout`, and is not run if formatting is cancelled. It does not support command templates.
+- `setupCommand` - Command to run a single time before this command formats its first file. It runs to completion before any formatting starts, which is useful for one-time setup that would otherwise race when formatting in parallel (ex. installing a toolchain). It is only run when a file actually matches this command, runs in the command's `cwd`, is not subject to the `timeout`, and is not run if formatting is cancelled. It does not support command templates.
 
 Command templates (ex. see the prettier example above):
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -176,7 +176,7 @@ pub async fn format_bytes(
     // run the command's setup once before formatting with it for the first time
     if let Some(setup_command) = &command.setup_command {
       match setup_state
-        .run_once(&command.cwd, setup_command, &config, &token)
+        .run_once(&command.cwd, setup_command, &token)
         .await?
       {
         SetupRun::Completed => {}
@@ -368,7 +368,6 @@ impl SetupState {
     &self,
     cwd: &Path,
     setup_command: &SetupCommand,
-    config: &Configuration,
     token: &Arc<dyn CancellationToken>,
   ) -> Result<SetupRun> {
     // the cwd is part of the key because the same command run in different
@@ -387,7 +386,7 @@ impl SetupState {
     // the others wait for it to finish; a failure is not cached so it can be
     // retried by the next file rather than poisoning all formatting
     match cell
-      .get_or_try_init(|| run_setup_command(cwd, setup_command, config, token))
+      .get_or_try_init(|| run_setup_command(cwd, setup_command, token))
       .await
     {
       Ok(()) => Ok(SetupRun::Completed),
@@ -400,7 +399,6 @@ impl SetupState {
 async fn run_setup_command(
   cwd: &Path,
   setup_command: &SetupCommand,
-  config: &Configuration,
   token: &Arc<dyn CancellationToken>,
 ) -> Result<(), SetupInitError> {
   let mut child = ChildKillOnDrop(
@@ -442,12 +440,6 @@ async fn run_setup_command(
 
   tokio::select! {
     _ = token.wait_cancellation() => Err(SetupInitError::Cancelled),
-    _ = tokio::time::sleep(Duration::from_secs(config.timeout as u64)) => {
-      Err(SetupInitError::Failed(anyhow!(
-        "Setup command has not returned a result within {} seconds.",
-        config.timeout,
-      )))
-    }
     result = result_future => match result {
       Ok(exit_status) if exit_status.success() => Ok(()),
       Ok(exit_status) => Err(SetupInitError::Failed(anyhow!(


### PR DESCRIPTION
The setup command was subject to the same `timeout` as formatting commands, which would abort long-running one-time setup (e.g. installing a toolchain). This removes the timeout from the setup command so it can run to completion.

- Drop the `tokio::time::sleep` timeout branch from `run_setup_command`'s `select!`.
- Remove the now-unused `config` parameter threaded through `run_once`/`run_setup_command`.
- Update README to note `setupCommand` is no longer subject to `timeout`.